### PR TITLE
feat: support for custom OpenAI API URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "bmo-chatbot",
-			"version": "1.4.3",
+			"version": "1.5.0",
 			"license": "MIT",
 			"dependencies": {
 				"marked": "^4.3.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { BMOSettingTab } from './settings';
 import './commands';
 
 export interface BMOSettings {
+	baseAPIUrl: any;
 	models: any;
 	apiKey: string;
 	max_tokens: string;
@@ -20,6 +21,7 @@ export interface BMOSettings {
 }
 
 export const DEFAULT_SETTINGS: BMOSettings = {
+	baseAPIUrl:"https://api.openai.com/v1",
 	apiKey: '',
 	max_tokens: '',
 	model: 'gpt-3.5-turbo',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -317,6 +317,17 @@ export class BMOSettingTab extends PluginSettingTab {
 					await this.plugin.saveSettings();
 				})
 		);
+		new Setting(containerEl)
+		.setName('OpenAI API URL')
+		.setDesc('Enter your OpenAI API URL')
+		.addText(text => text
+			.setPlaceholder('https://api.openai.com/v1')
+			.setValue(this.plugin.settings.baseAPIUrl || DEFAULT_SETTINGS.baseAPIUrl)
+			.onChange(async (value) => {
+					this.plugin.settings.baseAPIUrl = value ? value : DEFAULT_SETTINGS.baseAPIUrl;
+					await this.plugin.saveSettings();
+				})
+		);
 
 		function descLink1(text: string, link: string, extraWords: string): DocumentFragment {
 			const frag = new DocumentFragment();

--- a/src/view.ts
+++ b/src/view.ts
@@ -828,6 +828,7 @@ async function fetchOpenAIAPI(
     {
     const openai = new OpenAI({
         apiKey: settings.apiKey,
+        baseURL: settings.baseAPIUrl,
         dangerouslyAllowBrowser: true, // apiKey is stored within data.json
     });
 


### PR DESCRIPTION
This commit introduces the ability to configure a custom URL for the OpenAI API. This is particularly useful for users who might be operating with different API endpoints or are using a local setup. Users can now specify their desired API URL, enhancing flexibility and adaptability.