### PR TITLE
handle responses.json when it is an array

### DIFF
--- a/src/components/FetchModelList.ts
+++ b/src/components/FetchModelList.ts
@@ -88,8 +88,14 @@ export async function fetchRESTAPIURLModels(plugin: BMOGPT) {
             });
 
             // Check if the response is valid
-            if (response.json && response.json.data) {
-                const models = response.json.data.map((model: { id: number; }) => model.id);
+            if (response.json && (response.json.data || Array.isArray(response.json))) {
+				let models;
+				if (Array.isArray(response.json)) {
+					models = response.json.map((model: { id: number; }) => model.id);
+				} else {
+					models = response.json.data.map((model: { id: number; }) => model.id);
+				}
+
                 plugin.settings.RESTAPIURLConnection.RESTAPIURLModels = models;
                 return models;
             }


### PR DESCRIPTION
When I connect the BMO Plugin to together.ai openAI API endpoint, the models failed to load.
After investigation I noticed that the response.json is an Array that contains all models directly.
There is no data attribute needed.

I am not sure how other APIs implement this, however this fix made it work for me with together.ai...