### PR TITLE
Added new OpenAI models (GPT-4o etc...) to OPENAI_MODELS

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ To start using the plugin, enable it in your settings menu and insert an API key
     -   gpt-3.5-turbo-1106
     -   gpt-4
     -   gpt-4-turbo-preview
+    -   gpt-4-turbo
+    -   gpt-4-turbo-2024-04-09
+    -   gpt-4o
+    -   gpt-4o-2024-05-13
 -   Any Openrouter provided models.
 
 ## Other Notes

--- a/src/view.ts
+++ b/src/view.ts
@@ -21,7 +21,7 @@ import { fetchOpenAIAPIResponseStream,
 
 export const VIEW_TYPE_CHATBOT = 'chatbot-view';
 export const ANTHROPIC_MODELS = ['claude-instant-1.2', 'claude-2.0', 'claude-2.1', 'claude-3-opus-20240229', 'claude-3-sonnet-20240229'];
-export const OPENAI_MODELS = ['gpt-3.5-turbo', 'gpt-3.5-turbo-1106', 'gpt-4', 'gpt-4-turbo-preview'];
+export const OPENAI_MODELS = ['gpt-3.5-turbo', 'gpt-3.5-turbo-1106', 'gpt-4', 'gpt-4-turbo-preview', 'gpt-4-turbo', 'gpt-4-turbo-2024-04-09', 'gpt-4o', 'gpt-4o-2024-05-13',];
 
 export function filenameMessageHistoryJSON(plugin: BMOGPT) {
     const filenameMessageHistoryPath = './.obsidian/plugins/bmo-chatbot/data/';


### PR DESCRIPTION
It is working in my obsidian.

Added the following OpenAI models to the OPENAI_MODELS list in view.ts:
- gpt-4-turbo
- gpt-4-turbo-2024-04-09
- gpt-4o
- gpt-4o-2024-05-13

Added the following OpenAI models to the "Supported Models" section in README.md:
- gpt-4-turbo
- gpt-4-turbo-2024-04-09
- gpt-4o
- gpt-4o-2024-05-13

Please try it, since 4o is cheaper and faster, it brings better UX.