### PR TITLE
Patch for 121

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,9 @@ To start using the plugin, enable it in your settings menu and insert an API key
     -   claude-2.1
     -   claude-3-haiku-20240307
     -   claude-3-sonnet-20240229
-    -   claude-3-5-sonnet-20240620
-    -   claude-3-opus-20240229
+    -   claude-3-opus-latest
+    -   claude-3-5-haiku-latest
+    -   claude-3-5-sonnet-latest
 -   Mistral AI's models
 -   Google Gemini Models
 -   OpenAI

--- a/src/view.ts
+++ b/src/view.ts
@@ -21,7 +21,7 @@ import { fetchOpenAIAPIResponseStream,
         fetchGoogleGeminiResponseStream} from './components/FetchModelResponse';
 
 export const VIEW_TYPE_CHATBOT = 'chatbot-view';
-export const ANTHROPIC_MODELS = ['claude-instant-1.2', 'claude-2.0', 'claude-2.1', 'claude-3-haiku-20240307', 'claude-3-sonnet-20240229', 'claude-3-5-sonnet-latest', 'claude-3-opus-latest', 'claude-3-5-haiku-latest'];
+export const ANTHROPIC_MODELS = ['claude-instant-1.2', 'claude-2.0', 'claude-2.1', 'claude-3-haiku-20240307', 'claude-3-sonnet-20240229', 'claude-3-opus-latest', 'claude-3-5-haiku-latest', 'claude-3-5-sonnet-latest'];
 export const OPENAI_MODELS = ['gpt-3.5-turbo', 'gpt-4', 'gpt-4-turbo', 'gpt-4o', 'gpt-4o-mini'];
 
 export function fileNameMessageHistoryJson(plugin: BMOGPT) {

--- a/src/view.ts
+++ b/src/view.ts
@@ -21,7 +21,7 @@ import { fetchOpenAIAPIResponseStream,
         fetchGoogleGeminiResponseStream} from './components/FetchModelResponse';
 
 export const VIEW_TYPE_CHATBOT = 'chatbot-view';
-export const ANTHROPIC_MODELS = ['claude-instant-1.2', 'claude-2.0', 'claude-2.1', 'claude-3-haiku-20240307', 'claude-3-sonnet-20240229', 'claude-3-5-sonnet-20240620', 'claude-3-opus-20240229'];
+export const ANTHROPIC_MODELS = ['claude-instant-1.2', 'claude-2.0', 'claude-2.1', 'claude-3-haiku-20240307', 'claude-3-sonnet-20240229', 'claude-3-5-sonnet-latest', 'claude-3-opus-latest', 'claude-3-5-haiku-latest'];
 export const OPENAI_MODELS = ['gpt-3.5-turbo', 'gpt-4', 'gpt-4-turbo', 'gpt-4o', 'gpt-4o-mini'];
 
 export function fileNameMessageHistoryJson(plugin: BMOGPT) {


### PR DESCRIPTION
A small change to include the latest versions of Claude models, to resolve issue #121 which I just opened about this.

As a followup, I would propose removing all the old model versions, which don't (and I assume won't) be given a `-latest` tag by Anthropic, as to the best of my understanding, Anthropic consider the trio of `claude-3-opus-latest`, `claude-3-5-haiku-latest` and `claude-3-5-sonnet-latest` to supersede all their other models.