### PR TITLE
Add inline generation features with hotkeys, context menu, and streaming; add raw prompt logging for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# Notes on this fork
+
+Compared to the original repository, the dev branch of this fork contains the following added features:
+
+- Inline generation within the editor, with support for streaming, along with associated hotkeys and right-click context menu actions:
+  - Highlight text to limit the generation's context to the highlighted text
+  - Generate text at the cursor location, using what is above the cursor as context (but nothing below the cursor)
+  - Highlight text and use it as context with added instructions (an input popup appears). This is in contrast to the existing feature which uses the highlighted text as a prompt, verbatim.
+- An option to automatically create logs of the raw prompts sent to the model. Very useful for debugging and learning how to use
+the plugin.
+
 # BMO Chatbot for Obsidian
 
 Generate and brainstorm ideas while creating your notes using Large Language Models (LLMs) from Ollama, LM Studio, Anthropic, Google Gemini, Mistral AI, OpenAI, and more for Obsidian.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,3 @@
-# Notes on this fork
-
-Compared to the original repository, the dev branch of this fork contains the following added features:
-
-- Inline generation within the editor, with support for streaming, along with associated hotkeys and right-click context menu actions:
-  - Highlight text to limit the generation's context to the highlighted text
-  - Generate text at the cursor location, using what is above the cursor as context (but nothing below the cursor)
-  - Highlight text and use it as context with added instructions (an input popup appears). This is in contrast to the existing feature which uses the highlighted text as a prompt, verbatim.
-- An option to automatically create logs of the raw prompts sent to the model. Very useful for debugging and learning how to use
-the plugin.
-
 # BMO Chatbot for Obsidian
 
 Generate and brainstorm ideas while creating your notes using Large Language Models (LLMs) from Ollama, LM Studio, Anthropic, Google Gemini, Mistral AI, OpenAI, and more for Obsidian.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-	"id": "bmo-chatbot-fork",
-	"name": "BMO Chatbot-fork",
-	"version": "1.0.0",
+	"id": "bmo-chatbot",
+	"name": "BMO Chatbot",
+	"version": "2.3.3",
 	"minAppVersion": "1.0.0",
 	"description": "Generate and brainstorm ideas while creating your notes using Large Language Models (LLMs) from Ollama, LM Studio, Anthropic, Google Gemini, Mistral AI, OpenAI, and more for Obsidian.",
 	"author": "Longy2k",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-	"id": "bmo-chatbot",
-	"name": "BMO Chatbot",
-	"version": "2.3.3",
+	"id": "bmo-chatbot-fork",
+	"name": "BMO Chatbot-fork",
+	"version": "1.0.0",
 	"minAppVersion": "1.0.0",
 	"description": "Generate and brainstorm ideas while creating your notes using Large Language Models (LLMs) from Ollama, LM Studio, Anthropic, Google Gemini, Mistral AI, OpenAI, and more for Obsidian.",
 	"author": "Longy2k",

--- a/src/components/FetchModelEditor.ts
+++ b/src/components/FetchModelEditor.ts
@@ -1,8 +1,19 @@
-import { requestUrl } from 'obsidian';
-import { BMOSettings } from 'src/main';
+import { App, Editor, EditorPosition, requestUrl } from 'obsidian';
+import { BMOSettings } from '../main';
+import { logRawPrompt } from '../utils/PromptLogger';
 
-// Request response from Ollama REST API URL (editor)
-export async function fetchOllamaResponseEditor(settings: BMOSettings, prompt: string, model?: string, temperature?: string, maxTokens?: string, signal?: AbortSignal) {
+// Request response from Ollama REST API URL (editor) with streaming
+export async function fetchOllamaResponseEditorStream(
+    settings: BMOSettings, 
+    prompt: string, 
+    editor: Editor,
+    insertPosition: EditorPosition,
+    model?: string, 
+    temperature?: string, 
+    maxTokens?: string, 
+    signal?: AbortSignal, 
+    app?: App
+) {
     const ollamaRESTAPIURL = settings.OllamaConnection.RESTAPIURL;
 
     if (!ollamaRESTAPIURL) {
@@ -17,14 +28,14 @@ export async function fetchOllamaResponseEditor(settings: BMOSettings, prompt: s
         .filter(link => /\.(jpg|jpeg|png|gif|webp|bmp|tiff|tif|svg)$/i.test(link))
     : [];
 
-    // // Initialize an array to hold the absolute URLs
-    const imagesVaultPath: Uint8Array[] | string[] | null = [];
+    // Initialize an array to hold the absolute URLs
+    const imagesVaultPath: string[] = [];
 
     // Loop through each image link to get the full path
-    if (imageLink.length > 0) {
+    if (imageLink.length > 0 && app) {
         imageLink.forEach(link => {
-            const imageFile = this.app.metadataCache.getFirstLinkpathDest(link, '');
-            const image = imageFile ? this.app.vault.adapter.getFullPath(imageFile.path) : null;
+            const imageFile = app.metadataCache.getFirstLinkpathDest(link, '');
+            const image = imageFile ? app.vault.getResourcePath(imageFile) : null;
             if (image) {
                 imagesVaultPath.push(image);
             }
@@ -32,6 +43,131 @@ export async function fetchOllamaResponseEditor(settings: BMOSettings, prompt: s
     }
 
     try {
+        if (app && settings.prompts.logRawPrompts) {
+            await logRawPrompt(
+                app.vault,
+                settings,
+                prompt,
+                model || settings.general.model,
+                settings.editor.systen_role,
+                temperature || settings.general.temperature,
+                maxTokens || settings.general.max_tokens
+            );
+        }
+
+        const response = await fetch(ollamaRESTAPIURL + '/api/generate', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                model: model || settings.general.model,
+                system: settings.editor.systen_role,
+                prompt: prompt,
+                images: imagesVaultPath,
+                stream: true,
+                keep_alive: parseInt(settings.OllamaConnection.ollamaParameters.keep_alive),
+                options: {
+                    temperature: temperature ? parseFloat(temperature) : parseFloat(settings.general.temperature),
+                    num_predict: maxTokens ? parseInt(maxTokens) : parseInt(settings.general.max_tokens),
+                },
+            }),
+            signal: signal,
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        if (!response.body) {
+            throw new Error('Response body is null');
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let accumulatedResponse = '';
+
+        while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+
+            const chunk = decoder.decode(value, { stream: true });
+            const lines = chunk.split('\n');
+
+            for (const line of lines) {
+                if (line.trim() === '') continue;
+
+                try {
+                    const json = JSON.parse(line);
+                    if (json.response) {
+                        // Append at current position and create new position
+                        const currentPosition = {
+                            line: insertPosition.line,
+                            ch: insertPosition.ch + accumulatedResponse.length
+                        };
+                        editor.replaceRange(json.response, currentPosition);
+                        accumulatedResponse += json.response;
+                    }
+                } catch (e) {
+                    console.error('Error parsing JSON:', e);
+                }
+            }
+        }
+
+        // Don't return the response since we've already streamed it
+        return '';
+    } catch (error) {
+        if (error.name === 'AbortError') {
+            console.log('Request aborted');
+        } else {
+            console.error('Ollama request:', error);
+            throw error;
+        }
+    }
+}
+
+// Request response from Ollama REST API URL (editor)
+export async function fetchOllamaResponseEditor(settings: BMOSettings, prompt: string, model?: string, temperature?: string, maxTokens?: string, signal?: AbortSignal, app?: App) {
+    const ollamaRESTAPIURL = settings.OllamaConnection.RESTAPIURL;
+
+    if (!ollamaRESTAPIURL) {
+        return;
+    }
+
+    // Extract image links from the input
+    const imageMatch = prompt.match(/!?\[\[(.*?)\]\]/g);
+    const imageLink = imageMatch 
+    ? imageMatch
+        .map(item => item.startsWith('!') ? item.slice(3, -2) : item.slice(2, -2))
+        .filter(link => /\.(jpg|jpeg|png|gif|webp|bmp|tiff|tif|svg)$/i.test(link))
+    : [];
+
+    // Initialize an array to hold the absolute URLs
+    const imagesVaultPath: string[] = [];
+
+    // Loop through each image link to get the full path
+    if (imageLink.length > 0 && app) {
+        imageLink.forEach(link => {
+            const imageFile = app.metadataCache.getFirstLinkpathDest(link, '');
+            const image = imageFile ? app.vault.getResourcePath(imageFile) : null;
+            if (image) {
+                imagesVaultPath.push(image);
+            }
+        });
+    }
+
+    try {
+        if (app && settings.prompts.logRawPrompts) {
+            await logRawPrompt(
+                app.vault,
+                settings,
+                prompt,
+                model || settings.general.model,
+                settings.editor.systen_role,
+                temperature || settings.general.temperature,
+                maxTokens || settings.general.max_tokens
+            );
+        }
         const response = await fetch(ollamaRESTAPIURL + '/api/generate', {
             method: 'POST',
             headers: {
@@ -65,9 +201,116 @@ export async function fetchOllamaResponseEditor(settings: BMOSettings, prompt: s
     }
 }
 
-// Request response from openai-based rest api url (editor)
-export async function fetchRESTAPIURLDataEditor(settings: BMOSettings, prompt: string, model?: string, temperature?: string, maxTokens?: string, signal?: AbortSignal) {
+// Request response from openai-based rest api url (editor) with streaming
+export async function fetchRESTAPIURLDataEditorStream(
+    settings: BMOSettings, 
+    prompt: string,
+    editor: Editor,
+    insertPosition: EditorPosition,
+    model?: string, 
+    temperature?: string, 
+    maxTokens?: string, 
+    signal?: AbortSignal, 
+    app?: App
+) {
     try {
+        if (app && settings.prompts.logRawPrompts) {
+            await logRawPrompt(
+                app.vault,
+                settings,
+                prompt,
+                model || settings.general.model,
+                settings.editor.systen_role,
+                temperature || settings.general.temperature,
+                maxTokens || settings.general.max_tokens
+            );
+        }
+
+        const response = await fetch(settings.RESTAPIURLConnection.RESTAPIURL + '/chat/completions', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${settings.RESTAPIURLConnection.APIKey}`
+            },
+            body: JSON.stringify({
+                model: model || settings.general.model,
+                messages: [
+                    { role: 'system', content: settings.editor.systen_role || 'You are a helpful assistant.' },
+                    { role: 'user', content: prompt }
+                ],
+                max_tokens: parseInt(maxTokens || settings.general.max_tokens || '-1'),
+                temperature: parseFloat(temperature || settings.general.temperature),
+                stream: true
+            }),
+            signal: signal
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        if (!response.body) {
+            throw new Error('Response body is null');
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let accumulatedResponse = '';
+
+        while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+
+            const chunk = decoder.decode(value, { stream: true });
+            const lines = chunk.split('\n');
+
+            for (const line of lines) {
+                if (line.trim() === '' || line.trim() === 'data: [DONE]') continue;
+
+                try {
+                    const json = JSON.parse(line.replace(/^data: /, ''));
+                    if (json.choices[0].delta?.content) {
+                        const content = json.choices[0].delta.content;
+                        // Calculate new position based on accumulated content
+                        const currentPosition = {
+                            line: insertPosition.line,
+                            ch: insertPosition.ch + accumulatedResponse.length
+                        };
+                        editor.replaceRange(content, currentPosition);
+                        accumulatedResponse += content;
+                    }
+                } catch (e) {
+                    console.error('Error parsing JSON:', e);
+                }
+            }
+        }
+
+        // Don't return the response since we've already streamed it
+        return '';
+    } catch (error) {
+        if (error.name === 'AbortError') {
+            console.log('Request aborted');
+        } else {
+            console.error('Error making API request:', error);
+            throw error;
+        }
+    }
+}
+
+// Request response from openai-based rest api url (editor)
+export async function fetchRESTAPIURLDataEditor(settings: BMOSettings, prompt: string, model?: string, temperature?: string, maxTokens?: string, signal?: AbortSignal, app?: App) {
+    try {
+        if (app && settings.prompts.logRawPrompts) {
+            await logRawPrompt(
+                app.vault,
+                settings,
+                prompt,
+                model || settings.general.model,
+                settings.editor.systen_role,
+                temperature || settings.general.temperature,
+                maxTokens || settings.general.max_tokens
+            );
+        }
         const response = await fetch(settings.RESTAPIURLConnection.RESTAPIURL + '/chat/completions', {
             method: 'POST',
             headers: {
@@ -101,8 +344,19 @@ export async function fetchRESTAPIURLDataEditor(settings: BMOSettings, prompt: s
 }
 
 // Fetch Anthropic API Editor
-export async function fetchAnthropicResponseEditor(settings: BMOSettings, prompt: string, model?: string, temperature?: string, maxTokens?: string, signal?: AbortSignal) {
+export async function fetchAnthropicResponseEditor(settings: BMOSettings, prompt: string, model?: string, temperature?: string, maxTokens?: string, signal?: AbortSignal, app?: App) {
     try {
+        if (app && settings.prompts.logRawPrompts) {
+            await logRawPrompt(
+                app.vault,
+                settings,
+                prompt,
+                model || settings.general.model,
+                settings.editor.systen_role,
+                temperature || settings.general.temperature,
+                maxTokens || settings.general.max_tokens
+            );
+        }
         const response = await requestUrl({
             url: 'https://api.anthropic.com/v1/messages',
             method: 'POST',
@@ -130,9 +384,119 @@ export async function fetchAnthropicResponseEditor(settings: BMOSettings, prompt
     }
 }
 
-// Fetch Google Gemini API Editor
-export async function fetchGoogleGeminiDataEditor(settings: BMOSettings, prompt: string, model?: string, temperature?: string, maxTokens?: string, signal?: AbortSignal) {
+// Fetch Google Gemini API Editor with streaming
+export async function fetchGoogleGeminiDataEditorStream(
+    settings: BMOSettings, 
+    prompt: string,
+    editor: Editor,
+    insertPosition: EditorPosition,
+    model?: string, 
+    temperature?: string, 
+    maxTokens?: string, 
+    signal?: AbortSignal, 
+    app?: App
+) {
     try {
+        if (app && settings.prompts.logRawPrompts) {
+            await logRawPrompt(
+                app.vault,
+                settings,
+                prompt,
+                model || settings.general.model,
+                settings.editor.systen_role,
+                temperature || settings.general.temperature,
+                maxTokens || settings.general.max_tokens
+            );
+        }
+
+        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:streamGenerateContent?key=${settings.APIConnections.googleGemini.APIKey}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                contents: [
+                    {
+                        parts: [
+                            { text: settings.editor.systen_role + prompt }
+                        ]
+                    }
+                ],
+                model: model || settings.general.model,
+                generationConfig: {
+                    temperature: parseFloat(temperature || settings.general.temperature),
+                    maxOutputTokens: parseInt(maxTokens || settings.general.max_tokens) || 4096,
+                }
+            }),
+            signal: signal,
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        if (!response.body) {
+            throw new Error('Response body is null');
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let accumulatedResponse = '';
+
+        while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+
+            const chunk = decoder.decode(value, { stream: true });
+            const lines = chunk.split('\n');
+
+            for (const line of lines) {
+                if (line.trim() === '' || line.trim() === 'data: [DONE]') continue;
+
+                try {
+                    const json = JSON.parse(line.replace(/^data: /, ''));
+                    if (json.candidates?.[0]?.content?.parts?.[0]?.text) {
+                        const content = json.candidates[0].content.parts[0].text;
+                        // Calculate new position based on accumulated content
+                        const currentPosition = {
+                            line: insertPosition.line,
+                            ch: insertPosition.ch + accumulatedResponse.length
+                        };
+                        editor.replaceRange(content, currentPosition);
+                        accumulatedResponse += content;
+                    }
+                } catch (e) {
+                    console.error('Error parsing JSON:', e);
+                }
+            }
+        }
+
+        // Don't return the response since we've already streamed it
+        return '';
+    } catch (error) {
+        if (error.name === 'AbortError') {
+            console.log('Request aborted');
+        } else {
+            console.error('Error making API request:', error);
+            throw error;
+        }
+    }
+}
+
+// Fetch Google Gemini API Editor
+export async function fetchGoogleGeminiDataEditor(settings: BMOSettings, prompt: string, model?: string, temperature?: string, maxTokens?: string, signal?: AbortSignal, app?: App) {
+    try {
+        if (app && settings.prompts.logRawPrompts) {
+            await logRawPrompt(
+                app.vault,
+                settings,
+                prompt,
+                model || settings.general.model,
+                settings.editor.systen_role,
+                temperature || settings.general.temperature,
+                maxTokens || settings.general.max_tokens
+            );
+        }
         const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${settings.APIConnections.googleGemini.APIKey}`, {
             method: 'POST',
             headers: {
@@ -163,9 +527,116 @@ export async function fetchGoogleGeminiDataEditor(settings: BMOSettings, prompt:
     }
 }
 
-// Fetch Mistral API Editor
-export async function fetchMistralDataEditor(settings: BMOSettings, prompt: string, model?: string, temperature?: string, maxTokens?: string, signal?: AbortSignal) {
+// Fetch Mistral API Editor with streaming
+export async function fetchMistralDataEditorStream(
+    settings: BMOSettings, 
+    prompt: string,
+    editor: Editor,
+    insertPosition: EditorPosition,
+    model?: string, 
+    temperature?: string, 
+    maxTokens?: string, 
+    signal?: AbortSignal, 
+    app?: App
+) {
     try {
+        if (app && settings.prompts.logRawPrompts) {
+            await logRawPrompt(
+                app.vault,
+                settings,
+                prompt,
+                model || settings.general.model,
+                settings.editor.systen_role,
+                temperature || settings.general.temperature,
+                maxTokens || settings.general.max_tokens
+            );
+        }
+
+        const response = await fetch('https://api.mistral.ai/v1/chat/completions', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${settings.APIConnections.mistral.APIKey}`
+            },
+            body: JSON.stringify({
+                model: model || settings.general.model,
+                messages: [
+                    { role: 'system', content: settings.editor.systen_role },
+                    { role: 'user', content: prompt }
+                ],
+                max_tokens: parseInt(maxTokens || settings.general.max_tokens),
+                temperature: parseFloat(temperature || settings.general.temperature),
+                stream: true
+            }),
+            signal: signal,
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        if (!response.body) {
+            throw new Error('Response body is null');
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let accumulatedResponse = '';
+
+        while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+
+            const chunk = decoder.decode(value, { stream: true });
+            const lines = chunk.split('\n');
+
+            for (const line of lines) {
+                if (line.trim() === '' || line.trim() === 'data: [DONE]') continue;
+
+                try {
+                    const json = JSON.parse(line.replace(/^data: /, ''));
+                    if (json.choices[0].delta?.content) {
+                        const content = json.choices[0].delta.content;
+                        // Calculate new position based on accumulated content
+                        const currentPosition = {
+                            line: insertPosition.line,
+                            ch: insertPosition.ch + accumulatedResponse.length
+                        };
+                        editor.replaceRange(content, currentPosition);
+                        accumulatedResponse += content;
+                    }
+                } catch (e) {
+                    console.error('Error parsing JSON:', e);
+                }
+            }
+        }
+
+        // Don't return the response since we've already streamed it
+        return '';
+    } catch (error) {
+        if (error.name === 'AbortError') {
+            console.log('Request aborted');
+        } else {
+            console.error('Error making API request:', error);
+            throw error;
+        }
+    }
+}
+
+// Fetch Mistral API Editor
+export async function fetchMistralDataEditor(settings: BMOSettings, prompt: string, model?: string, temperature?: string, maxTokens?: string, signal?: AbortSignal, app?: App) {
+    try {
+        if (app && settings.prompts.logRawPrompts) {
+            await logRawPrompt(
+                app.vault,
+                settings,
+                prompt,
+                model || settings.general.model,
+                settings.editor.systen_role,
+                temperature || settings.general.temperature,
+                maxTokens || settings.general.max_tokens
+            );
+        }
         const response = await fetch('https://api.mistral.ai/v1/chat/completions', {
             method: 'POST',
             headers: {
@@ -193,36 +664,254 @@ export async function fetchMistralDataEditor(settings: BMOSettings, prompt: stri
     }
 }
 
-// Fetch OpenAI-Based API Editor
-export async function fetchOpenAIBaseAPIResponseEditor(settings: BMOSettings, prompt: string, model?: string, temperature?: string, maxTokens?: string, signal?: AbortSignal) {
-    const response = await fetch(`${settings.APIConnections.openAI.openAIBaseUrl}/chat/completions`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${settings.APIConnections.openAI.APIKey}`,
-        },
-        body: JSON.stringify({
-          model: model || settings.general.model,
-          max_tokens: parseInt(maxTokens || settings.general.max_tokens),
-          temperature: parseFloat(temperature || settings.general.temperature),
-          stream: false,
-          messages: [
-            { role: 'system', content: settings.editor.systen_role },
-            { role: 'user', content: prompt}
-        ],
-        }),
-        signal: signal,
-    });
-      
-    const data = await response.json();
-    const message = data.choices[0].message.content || '';
+// Fetch OpenAI-Based API Editor with streaming
+export async function fetchOpenAIBaseAPIResponseEditorStream(
+    settings: BMOSettings, 
+    prompt: string,
+    editor: Editor,
+    insertPosition: EditorPosition,
+    model?: string, 
+    temperature?: string, 
+    maxTokens?: string, 
+    signal?: AbortSignal, 
+    app?: App
+) {
+    try {
+        if (app && settings.prompts.logRawPrompts) {
+            await logRawPrompt(
+                app.vault,
+                settings,
+                prompt,
+                model || settings.general.model,
+                settings.editor.systen_role,
+                temperature || settings.general.temperature,
+                maxTokens || settings.general.max_tokens
+            );
+        }
 
-    return message;
+        const response = await fetch(`${settings.APIConnections.openAI.openAIBaseUrl}/chat/completions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${settings.APIConnections.openAI.APIKey}`,
+            },
+            body: JSON.stringify({
+                model: model || settings.general.model,
+                max_tokens: parseInt(maxTokens || settings.general.max_tokens),
+                temperature: parseFloat(temperature || settings.general.temperature),
+                stream: true,
+                messages: [
+                    { role: 'system', content: settings.editor.systen_role },
+                    { role: 'user', content: prompt}
+                ],
+            }),
+            signal: signal,
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        if (!response.body) {
+            throw new Error('Response body is null');
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let accumulatedResponse = '';
+
+        while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+
+            const chunk = decoder.decode(value, { stream: true });
+            const lines = chunk.split('\n');
+
+            for (const line of lines) {
+                if (line.trim() === '' || line.trim() === 'data: [DONE]') continue;
+
+                try {
+                    const json = JSON.parse(line.replace(/^data: /, ''));
+                    if (json.choices[0].delta?.content) {
+                        const content = json.choices[0].delta.content;
+                        // Calculate new position based on accumulated content
+                        const currentPosition = {
+                            line: insertPosition.line,
+                            ch: insertPosition.ch + accumulatedResponse.length
+                        };
+                        editor.replaceRange(content, currentPosition);
+                        accumulatedResponse += content;
+                    }
+                } catch (e) {
+                    console.error('Error parsing JSON:', e);
+                }
+            }
+        }
+
+        // Don't return the response since we've already streamed it
+        return '';
+    } catch (error) {
+        if (error.name === 'AbortError') {
+            console.log('Request aborted');
+        } else {
+            console.error('Error making API request:', error);
+            throw error;
+        }
+    }
 }
 
-// Request response from openai-based rest api url (editor)
-export async function fetchOpenRouterEditor(settings: BMOSettings, prompt: string, model?: string, temperature?: string, maxTokens?: string, signal?: AbortSignal) {
+// Fetch OpenAI-Based API Editor
+export async function fetchOpenAIBaseAPIResponseEditor(settings: BMOSettings, prompt: string, model?: string, temperature?: string, maxTokens?: string, signal?: AbortSignal, app?: App) {
     try {
+        if (app && settings.prompts.logRawPrompts) {
+            await logRawPrompt(
+                app.vault,
+                settings,
+                prompt,
+                model || settings.general.model,
+                settings.editor.systen_role,
+                temperature || settings.general.temperature,
+                maxTokens || settings.general.max_tokens
+            );
+        }
+        const response = await fetch(`${settings.APIConnections.openAI.openAIBaseUrl}/chat/completions`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${settings.APIConnections.openAI.APIKey}`,
+            },
+            body: JSON.stringify({
+                model: model || settings.general.model,
+                max_tokens: parseInt(maxTokens || settings.general.max_tokens),
+                temperature: parseFloat(temperature || settings.general.temperature),
+                stream: false,
+                messages: [
+                    { role: 'system', content: settings.editor.systen_role },
+                    { role: 'user', content: prompt}
+                ],
+            }),
+            signal: signal,
+        });
+        
+        const data = await response.json();
+        const message = data.choices[0].message.content || '';
+        return message;
+    } catch (error) {
+        console.error('Error making API request:', error);
+        throw error;
+    }
+}
+
+// Request response from OpenRouter with streaming
+export async function fetchOpenRouterEditorStream(
+    settings: BMOSettings, 
+    prompt: string,
+    editor: Editor,
+    insertPosition: EditorPosition,
+    model?: string, 
+    temperature?: string, 
+    maxTokens?: string, 
+    signal?: AbortSignal, 
+    app?: App
+) {
+    try {
+        if (app && settings.prompts.logRawPrompts) {
+            await logRawPrompt(
+                app.vault,
+                settings,
+                prompt,
+                model || settings.general.model,
+                settings.editor.systen_role,
+                temperature || settings.general.temperature,
+                maxTokens || settings.general.max_tokens
+            );
+        }
+
+        const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${settings.APIConnections.openRouter.APIKey}`
+            },
+            body: JSON.stringify({
+                model: model || settings.general.model,
+                messages: [
+                    { role: 'system', content: settings.editor.systen_role },
+                    { role: 'user', content: prompt}
+                ],
+                max_tokens: parseInt(maxTokens || settings.general.max_tokens),
+                temperature: parseFloat(temperature || settings.general.temperature),
+                stream: true
+            }),
+            signal: signal,
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        if (!response.body) {
+            throw new Error('Response body is null');
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let accumulatedResponse = '';
+
+        while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+
+            const chunk = decoder.decode(value, { stream: true });
+            const lines = chunk.split('\n');
+
+            for (const line of lines) {
+                if (line.trim() === '' || line.trim() === 'data: [DONE]') continue;
+
+                try {
+                    const json = JSON.parse(line.replace(/^data: /, ''));
+                    if (json.choices[0].delta?.content) {
+                        const content = json.choices[0].delta.content;
+                        // Calculate new position based on accumulated content
+                        const currentPosition = {
+                            line: insertPosition.line,
+                            ch: insertPosition.ch + accumulatedResponse.length
+                        };
+                        editor.replaceRange(content, currentPosition);
+                        accumulatedResponse += content;
+                    }
+                } catch (e) {
+                    console.error('Error parsing JSON:', e);
+                }
+            }
+        }
+
+        // Don't return the response since we've already streamed it
+        return '';
+    } catch (error) {
+        if (error.name === 'AbortError') {
+            console.log('Request aborted');
+        } else {
+            console.error('Error making API request:', error);
+            throw error;
+        }
+    }
+}
+
+// Request response from OpenRouter without streaming
+export async function fetchOpenRouterEditor(settings: BMOSettings, prompt: string, model?: string, temperature?: string, maxTokens?: string, signal?: AbortSignal, app?: App) {
+    try {
+        if (app && settings.prompts.logRawPrompts) {
+            await logRawPrompt(
+                app.vault,
+                settings,
+                prompt,
+                model || settings.general.model,
+                settings.editor.systen_role,
+                temperature || settings.general.temperature,
+                maxTokens || settings.general.max_tokens
+            );
+        }
         const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
             method: 'POST',
             headers: {

--- a/src/components/editor/CursorCompletion.ts
+++ b/src/components/editor/CursorCompletion.ts
@@ -1,0 +1,249 @@
+import { Editor, MarkdownView, Notice, Plugin } from 'obsidian';
+import BMOGPT, { BMOSettings } from '../../main';
+import { 
+    fetchOllamaResponseEditor,
+    fetchOllamaResponseEditorStream,
+    fetchRESTAPIURLDataEditor,
+    fetchRESTAPIURLDataEditorStream,
+    fetchAnthropicResponseEditor,
+    fetchMistralDataEditor,
+    fetchMistralDataEditorStream,
+    fetchGoogleGeminiDataEditor,
+    fetchGoogleGeminiDataEditorStream,
+    fetchOpenAIBaseAPIResponseEditor,
+    fetchOpenAIBaseAPIResponseEditorStream,
+    fetchOpenRouterEditor,
+    fetchOpenRouterEditorStream
+} from '../FetchModelEditor';
+import { ANTHROPIC_MODELS, OPENAI_MODELS } from '../../view';
+
+let abortController: AbortController | null = null;
+
+export function stopCompletion() {
+    if (abortController) {
+        abortController.abort();
+        abortController = null;
+        new Notice('Completion stopped');
+    }
+}
+
+export async function cursorCompletionCommand(plugin: BMOGPT & Plugin, settings: BMOSettings) {
+    const view = plugin.app.workspace.getActiveViewOfType(MarkdownView);
+    if (!view) {
+        new Notice('No active markdown view');
+        return;
+    }
+
+    const editor = view.editor;
+    const selection = editor.getSelection();
+    const cursor = editor.getCursor();
+    let contextText: string;
+    let insertPosition = cursor;
+
+    if (selection && selection.trim() !== '') {
+        // If text is selected, use only that as context
+        contextText = selection;
+        // Find the end of selection to insert completion there
+        const selectionRange = editor.listSelections()[0];
+        insertPosition = selectionRange.head.line > selectionRange.anchor.line || 
+            (selectionRange.head.line === selectionRange.anchor.line && selectionRange.head.ch > selectionRange.anchor.ch) 
+            ? selectionRange.head 
+            : selectionRange.anchor;
+    } else {
+        // If no selection, use text up to cursor
+        contextText = editor.getRange({ line: 0, ch: 0 }, cursor);
+        if (!contextText) {
+            new Notice('No text found before cursor');
+            return;
+        }
+    }
+
+    // Create new abort controller for this completion
+    if (abortController) {
+        abortController.abort();
+    }
+    abortController = new AbortController();
+
+    const generatingNotice = new Notice('Generating...', 0);
+    try {
+        let response: string | undefined | null = '';
+
+        // Use existing fetch methods with abort controller
+        if (settings.OllamaConnection.RESTAPIURL && settings.OllamaConnection.ollamaModels.includes(settings.general.model)) {
+            if (settings.OllamaConnection.enableStream) {
+                response = await fetchOllamaResponseEditorStream(
+                    settings, 
+                    contextText,
+                    editor,
+                    insertPosition,
+                    undefined,
+                    undefined,
+                    undefined,
+                    abortController.signal,
+                    plugin.app
+                );
+            } else {
+                response = await fetchOllamaResponseEditor(
+                    settings,
+                    contextText,
+                    undefined,
+                    undefined,
+                    undefined,
+                    abortController.signal,
+                    plugin.app
+                );
+            }
+        }
+        else if (settings.RESTAPIURLConnection.RESTAPIURL && settings.RESTAPIURLConnection.RESTAPIURLModels.includes(settings.general.model)) {
+            if (settings.RESTAPIURLConnection.enableStream) {
+                response = await fetchRESTAPIURLDataEditorStream(
+                    settings,
+                    contextText,
+                    editor,
+                    insertPosition,
+                    undefined,
+                    undefined,
+                    undefined,
+                    abortController.signal,
+                    plugin.app
+                );
+            } else {
+                response = await fetchRESTAPIURLDataEditor(
+                    settings,
+                    contextText,
+                    undefined,
+                    undefined,
+                    undefined,
+                    abortController.signal,
+                    plugin.app
+                );
+            }
+        }
+        else if (ANTHROPIC_MODELS.includes(settings.general.model)) {
+            response = await fetchAnthropicResponseEditor(settings, contextText, undefined, undefined, undefined, abortController.signal, plugin.app);
+        }
+        else if (settings.APIConnections.mistral.mistralModels.includes(settings.general.model)) {
+            if (settings.APIConnections.mistral.enableStream) {
+                response = await fetchMistralDataEditorStream(
+                    settings,
+                    contextText,
+                    editor,
+                    insertPosition,
+                    undefined,
+                    undefined,
+                    undefined,
+                    abortController.signal,
+                    plugin.app
+                );
+            } else {
+                response = await fetchMistralDataEditor(
+                    settings,
+                    contextText,
+                    undefined,
+                    undefined,
+                    undefined,
+                    abortController.signal,
+                    plugin.app
+                );
+            }
+        }
+        else if (settings.APIConnections.googleGemini.geminiModels.includes(settings.general.model)) {
+            if (settings.APIConnections.googleGemini.enableStream) {
+                response = await fetchGoogleGeminiDataEditorStream(
+                    settings,
+                    contextText,
+                    editor,
+                    insertPosition,
+                    undefined,
+                    undefined,
+                    undefined,
+                    abortController.signal,
+                    plugin.app
+                );
+            } else {
+                response = await fetchGoogleGeminiDataEditor(
+                    settings,
+                    contextText,
+                    undefined,
+                    undefined,
+                    undefined,
+                    abortController.signal,
+                    plugin.app
+                );
+            }
+        }
+        else if (OPENAI_MODELS.includes(settings.general.model) || 
+                (settings.APIConnections.openAI.openAIBaseUrl !== 'https://api.openai.com/v1' && 
+                settings.APIConnections.openAI.openAIBaseModels.includes(settings.general.model))) {
+            if (settings.APIConnections.openAI.enableStream) {
+                response = await fetchOpenAIBaseAPIResponseEditorStream(
+                    settings,
+                    contextText,
+                    editor,
+                    insertPosition,
+                    undefined,
+                    undefined,
+                    undefined,
+                    abortController.signal,
+                    plugin.app
+                );
+            } else {
+                response = await fetchOpenAIBaseAPIResponseEditor(
+                    settings,
+                    contextText,
+                    undefined,
+                    undefined,
+                    undefined,
+                    abortController.signal,
+                    plugin.app
+                );
+            }
+        }
+        else if (settings.APIConnections.openRouter.openRouterModels.includes(settings.general.model)) {
+            if (settings.APIConnections.openRouter.enableStream) {
+                response = await fetchOpenRouterEditorStream(
+                    settings,
+                    contextText,
+                    editor,
+                    insertPosition,
+                    undefined,
+                    undefined,
+                    undefined,
+                    abortController.signal,
+                    plugin.app
+                );
+            } else {
+                response = await fetchOpenRouterEditor(
+                    settings,
+                    contextText,
+                    undefined,
+                    undefined,
+                    undefined,
+                    abortController.signal,
+                    plugin.app
+                );
+            }
+        }
+        else {
+            throw new Error('No compatible model found');
+        }
+
+        if (response) {
+            // Insert response at cursor position
+            editor.replaceRange(response, insertPosition);
+        }
+
+        generatingNotice.hide();
+        new Notice('Generation complete');
+    } catch (error) {
+        if (error.name === 'AbortError') {
+            new Notice('Generation stopped');
+        } else {
+            new Notice('Error generating completion: ' + error.message);
+            console.error(error);
+        }
+    } finally {
+        generatingNotice.hide();
+        abortController = null;
+    }
+}

--- a/src/components/editor/CursorCompletion.ts
+++ b/src/components/editor/CursorCompletion.ts
@@ -1,5 +1,5 @@
 import { Editor, MarkdownView, Notice, Plugin } from 'obsidian';
-import BMOGPT, { BMOSettings } from '../../main';
+import BMOGPT, { BMOSettings } from 'src/main';
 import { 
     fetchOllamaResponseEditor,
     fetchOllamaResponseEditorStream,
@@ -15,7 +15,7 @@ import {
     fetchOpenRouterEditor,
     fetchOpenRouterEditorStream
 } from '../FetchModelEditor';
-import { ANTHROPIC_MODELS, OPENAI_MODELS } from '../../view';
+import { ANTHROPIC_MODELS, OPENAI_MODELS } from 'src/view';
 
 let abortController: AbortController | null = null;
 
@@ -238,9 +238,15 @@ export async function cursorCompletionCommand(plugin: BMOGPT & Plugin, settings:
     } catch (error) {
         if (error.name === 'AbortError') {
             new Notice('Generation stopped');
+        } else if (error instanceof Error) {
+            const errorMessage = error.message.includes('No compatible model found') 
+                ? 'No compatible model found' 
+                : `Error generating completion: ${error.message}`;
+            new Notice(errorMessage);
+            console.error('Cursor completion error:', error);
         } else {
-            new Notice('Error generating completion: ' + error.message);
-            console.error(error);
+            new Notice('Unknown error occurred during generation');
+            console.error('Unknown cursor completion error:', error);
         }
     } finally {
         generatingNotice.hide();

--- a/src/components/editor/CursorCompletion.ts
+++ b/src/components/editor/CursorCompletion.ts
@@ -2,7 +2,6 @@ import { Editor, MarkdownView, Notice, Plugin } from 'obsidian';
 import BMOGPT, { BMOSettings } from 'src/main';
 import { 
     fetchOllamaResponseEditor,
-    fetchOllamaResponseEditorStream,
     fetchRESTAPIURLDataEditor,
     fetchRESTAPIURLDataEditorStream,
     fetchAnthropicResponseEditor,
@@ -70,29 +69,15 @@ export async function cursorCompletionCommand(plugin: BMOGPT & Plugin, settings:
 
         // Use existing fetch methods with abort controller
         if (settings.OllamaConnection.RESTAPIURL && settings.OllamaConnection.ollamaModels.includes(settings.general.model)) {
-            if (settings.OllamaConnection.enableStream) {
-                response = await fetchOllamaResponseEditorStream(
-                    settings, 
-                    contextText,
-                    editor,
-                    insertPosition,
-                    undefined,
-                    undefined,
-                    undefined,
-                    abortController.signal,
-                    plugin.app
-                );
-            } else {
-                response = await fetchOllamaResponseEditor(
-                    settings,
-                    contextText,
-                    undefined,
-                    undefined,
-                    undefined,
-                    abortController.signal,
-                    plugin.app
-                );
-            }
+            response = await fetchOllamaResponseEditor(
+                settings,
+                contextText,
+                undefined,
+                undefined,
+                undefined,
+                abortController.signal,
+                plugin.app
+            );
         }
         else if (settings.RESTAPIURLConnection.RESTAPIURL && settings.RESTAPIURLConnection.RESTAPIURLModels.includes(settings.general.model)) {
             if (settings.RESTAPIURLConnection.enableStream) {

--- a/src/components/editor/EditorCommands.ts
+++ b/src/components/editor/EditorCommands.ts
@@ -1,8 +1,16 @@
-import BMOGPT, { BMOSettings, DEFAULT_SETTINGS } from 'src/main';
+import BMOGPT, { BMOSettings, DEFAULT_SETTINGS } from '../../main';
 import { fetchModelRenameTitle } from './FetchRenameNoteTitle';
 import { MarkdownView, Notice } from 'obsidian';
-import { ANTHROPIC_MODELS, OPENAI_MODELS } from 'src/view';
-import { fetchOpenAIBaseAPIResponseEditor, fetchOllamaResponseEditor, fetchRESTAPIURLDataEditor, fetchAnthropicResponseEditor, fetchMistralDataEditor, fetchGoogleGeminiDataEditor, fetchOpenRouterEditor } from '../FetchModelEditor';
+import { ANTHROPIC_MODELS, OPENAI_MODELS } from '../../view';
+import { 
+    fetchOpenAIBaseAPIResponseEditor, 
+    fetchOllamaResponseEditor, 
+    fetchRESTAPIURLDataEditor, 
+    fetchAnthropicResponseEditor, 
+    fetchMistralDataEditor, 
+    fetchGoogleGeminiDataEditor, 
+    fetchOpenRouterEditor 
+} from '../FetchModelEditor';
 
 export async function renameTitleCommand(plugin: BMOGPT, settings: BMOSettings) {
     let uniqueNameFound = false;
@@ -50,14 +58,14 @@ export async function renameTitleCommand(plugin: BMOGPT, settings: BMOSettings) 
 }
 
 // Prompt + Select + Generate command
-export async function promptSelectGenerateCommand(plugin: BMOGPT, settings: BMOSettings) {
+export async function promptSelectGenerateCommand(plugin: BMOGPT, settings: BMOSettings, customPrompt?: string) {
     const view = plugin.app.workspace.getActiveViewOfType(MarkdownView);
-    const select = view?.editor.getSelection();
+    const select = customPrompt || view?.editor.getSelection();
     if (view && select && select.trim() !== '') {
         const generatingNotice = new Notice('Generating...', 0);
         if (settings.OllamaConnection.RESTAPIURL && settings.OllamaConnection.ollamaModels.includes(settings.general.model)) {
             try {
-                const response = await fetchOllamaResponseEditor(settings, select); 
+                const response = await fetchOllamaResponseEditor(settings, select, undefined, undefined, undefined, undefined, plugin.app); 
                 // Replace the current selection with the response
                 const cursorStart = view.editor.getCursor('from');
                 view.editor.replaceSelection(response ?? 'ERROR');
@@ -78,7 +86,7 @@ export async function promptSelectGenerateCommand(plugin: BMOGPT, settings: BMOS
         }
         else if (settings.RESTAPIURLConnection.RESTAPIURL && settings.RESTAPIURLConnection.RESTAPIURLModels.includes(settings.general.model)){
             try {
-                const response = await fetchRESTAPIURLDataEditor(settings, select); 
+                const response = await fetchRESTAPIURLDataEditor(settings, select, undefined, undefined, undefined, undefined, plugin.app); 
                 // Replace the current selection with the response
                 const cursorStart = view.editor.getCursor('from');
                 view.editor.replaceSelection(response);
@@ -99,7 +107,7 @@ export async function promptSelectGenerateCommand(plugin: BMOGPT, settings: BMOS
         }
         else if (ANTHROPIC_MODELS.includes(settings.general.model)) {
             try {
-                const response = await fetchAnthropicResponseEditor(settings, select); 
+                const response = await fetchAnthropicResponseEditor(settings, select, undefined, undefined, undefined, undefined, plugin.app); 
                 view.editor.replaceSelection(response);
             }
             catch (error) {
@@ -109,7 +117,7 @@ export async function promptSelectGenerateCommand(plugin: BMOGPT, settings: BMOS
         }
         else if (settings.APIConnections.googleGemini.geminiModels.includes(settings.general.model)) {
             try {
-                const response = await fetchGoogleGeminiDataEditor(settings, select); 
+                const response = await fetchGoogleGeminiDataEditor(settings, select, undefined, undefined, undefined, undefined, plugin.app); 
                 // Replace the current selection with the response
                 const cursorStart = view.editor.getCursor('from');
                 view.editor.replaceSelection(response);
@@ -130,7 +138,7 @@ export async function promptSelectGenerateCommand(plugin: BMOGPT, settings: BMOS
         }
         else if (settings.APIConnections.mistral.mistralModels.includes(settings.general.model)) {
             try {
-                const response = await fetchMistralDataEditor(settings, select); 
+                const response = await fetchMistralDataEditor(settings, select, undefined, undefined, undefined, undefined, plugin.app); 
                 // Replace the current selection with the response
                 const cursorStart = view.editor.getCursor('from');
                 view.editor.replaceSelection(response);
@@ -151,7 +159,7 @@ export async function promptSelectGenerateCommand(plugin: BMOGPT, settings: BMOS
         }
         else if (OPENAI_MODELS.includes(settings.general.model)) {
             try {
-                const response = await fetchOpenAIBaseAPIResponseEditor(settings, select); 
+                const response = await fetchOpenAIBaseAPIResponseEditor(settings, select, undefined, undefined, undefined, undefined, plugin.app); 
                 // Replace the current selection with the response
                 const cursorStart = view.editor.getCursor('from');
                 view.editor.replaceSelection(response || '');
@@ -172,7 +180,7 @@ export async function promptSelectGenerateCommand(plugin: BMOGPT, settings: BMOS
         }
         else if ((settings.APIConnections.openAI.openAIBaseUrl != DEFAULT_SETTINGS.APIConnections.openAI.openAIBaseUrl) && settings.APIConnections.openAI.openAIBaseModels.includes(settings.general.model)){
             try {
-                const response = await fetchOpenAIBaseAPIResponseEditor(settings, select); 
+                const response = await fetchOpenAIBaseAPIResponseEditor(settings, select, undefined, undefined, undefined, undefined, plugin.app); 
                 // Replace the current selection with the response
                 const cursorStart = view.editor.getCursor('from');
                 view.editor.replaceSelection(response || '');
@@ -193,7 +201,7 @@ export async function promptSelectGenerateCommand(plugin: BMOGPT, settings: BMOS
         }
         else if (settings.APIConnections.openRouter.openRouterModels.includes(settings.general.model)){
             try {
-                const response = await fetchOpenRouterEditor(settings, select); 
+                const response = await fetchOpenRouterEditor(settings, select, undefined, undefined, undefined, undefined, plugin.app); 
                 // Replace the current selection with the response
                 const cursorStart = view.editor.getCursor('from');
                 view.editor.replaceSelection(response);

--- a/src/components/editor/EditorCommands.ts
+++ b/src/components/editor/EditorCommands.ts
@@ -1,7 +1,7 @@
-import BMOGPT, { BMOSettings, DEFAULT_SETTINGS } from '../../main';
+import BMOGPT, { BMOSettings, DEFAULT_SETTINGS } from 'src/main';
 import { fetchModelRenameTitle } from './FetchRenameNoteTitle';
 import { MarkdownView, Notice } from 'obsidian';
-import { ANTHROPIC_MODELS, OPENAI_MODELS } from '../../view';
+import { ANTHROPIC_MODELS, OPENAI_MODELS } from 'src/view';
 import { 
     fetchOpenAIBaseAPIResponseEditor, 
     fetchOllamaResponseEditor, 

--- a/src/components/editor/EditorCommands.ts
+++ b/src/components/editor/EditorCommands.ts
@@ -1,7 +1,7 @@
-import BMOGPT, { BMOSettings, DEFAULT_SETTINGS } from 'src/main';
+import BMOGPT, { BMOSettings, DEFAULT_SETTINGS } from '../../main';
 import { fetchModelRenameTitle } from './FetchRenameNoteTitle';
 import { MarkdownView, Notice } from 'obsidian';
-import { ANTHROPIC_MODELS, OPENAI_MODELS } from 'src/view';
+import { ANTHROPIC_MODELS, OPENAI_MODELS } from '../../view';
 import { 
     fetchOpenAIBaseAPIResponseEditor, 
     fetchOllamaResponseEditor, 

--- a/src/components/modals/PromptInputModal.ts
+++ b/src/components/modals/PromptInputModal.ts
@@ -1,5 +1,5 @@
 import { App, Modal, Setting, TextAreaComponent, ButtonComponent } from 'obsidian';
-import BMOGPT, { BMOSettings } from '../../main';
+import BMOGPT, { BMOSettings } from 'src/main';
 import { promptSelectGenerateCommand } from '../editor/EditorCommands';
 
 export class PromptInputModal extends Modal {
@@ -8,6 +8,9 @@ export class PromptInputModal extends Modal {
     private settings: BMOSettings;
     private selectedText: string;
     private inputValue: string = '';
+    private generateButton: ButtonComponent;
+    private cancelButton: ButtonComponent;
+    private textArea: TextAreaComponent;
 
     constructor(app: App, plugin: BMOGPT, settings: BMOSettings, selectedText: string) {
         super(app);
@@ -25,30 +28,53 @@ export class PromptInputModal extends Modal {
         new Setting(contentEl)
             .setName('Your prompt')
             .setDesc('The selected text will be used as context for this prompt')
-            .addTextArea((text: TextAreaComponent) => text
-                .setPlaceholder('Enter your prompt here...')
-                .setValue(this.inputValue)
-                .onChange(value => {
-                    this.inputValue = value;
-                }));
+            .addTextArea((text: TextAreaComponent) => {
+                this.textArea = text;
+                text.setPlaceholder('Enter your prompt here...')
+                    .setValue(this.inputValue)
+                    .onChange(value => {
+                        this.inputValue = value;
+                    });
+            });
 
         new Setting(contentEl)
-            .addButton((btn: ButtonComponent) => btn
-                .setButtonText('Generate')
-                .setCta()
-                .onClick(() => {
-                    const fullPrompt = `Context:\n${this.selectedText}\n\nPrompt: ${this.inputValue}`;
-                    this.close();
-                    promptSelectGenerateCommand(this.plugin, this.settings, fullPrompt);
-                }))
-            .addButton((btn: ButtonComponent) => btn
-                .setButtonText('Cancel')
-                .onClick(() => {
-                    this.close();
-                }));
+            .addButton((btn: ButtonComponent) => {
+                this.generateButton = btn;
+                btn.setButtonText('Generate')
+                    .setCta()
+                    .onClick(() => {
+                        const fullPrompt = `Context:
+
+${this.selectedText}
+
+Prompt:
+${this.inputValue}`;
+                        this.close();
+                        promptSelectGenerateCommand(this.plugin, this.settings, fullPrompt);
+                    });
+            })
+            .addButton((btn: ButtonComponent) => {
+                this.cancelButton = btn;
+                btn.setButtonText('Cancel')
+                    .onClick(() => {
+                        this.close();
+                    });
+            });
     }
 
     onClose() {
+        // Remove event listeners
+        if (this.textArea) {
+            this.textArea.onChange(() => {});
+        }
+        if (this.generateButton) {
+            this.generateButton.onClick(() => {});
+        }
+        if (this.cancelButton) {
+            this.cancelButton.onClick(() => {});
+        }
+        
+        // Clear content
         const { contentEl } = this;
         contentEl.empty();
     }

--- a/src/components/modals/PromptInputModal.ts
+++ b/src/components/modals/PromptInputModal.ts
@@ -1,0 +1,55 @@
+import { App, Modal, Setting, TextAreaComponent, ButtonComponent } from 'obsidian';
+import BMOGPT, { BMOSettings } from '../../main';
+import { promptSelectGenerateCommand } from '../editor/EditorCommands';
+
+export class PromptInputModal extends Modal {
+    contentEl: HTMLElement;
+    private plugin: BMOGPT;
+    private settings: BMOSettings;
+    private selectedText: string;
+    private inputValue: string = '';
+
+    constructor(app: App, plugin: BMOGPT, settings: BMOSettings, selectedText: string) {
+        super(app);
+        this.plugin = plugin;
+        this.settings = settings;
+        this.selectedText = selectedText;
+    }
+
+    onOpen() {
+        const { contentEl } = this;
+        contentEl.empty();
+
+        contentEl.createEl('h3', { text: 'Enter Prompt' });
+
+        new Setting(contentEl)
+            .setName('Your prompt')
+            .setDesc('The selected text will be used as context for this prompt')
+            .addTextArea((text: TextAreaComponent) => text
+                .setPlaceholder('Enter your prompt here...')
+                .setValue(this.inputValue)
+                .onChange(value => {
+                    this.inputValue = value;
+                }));
+
+        new Setting(contentEl)
+            .addButton((btn: ButtonComponent) => btn
+                .setButtonText('Generate')
+                .setCta()
+                .onClick(() => {
+                    const fullPrompt = `Context:\n${this.selectedText}\n\nPrompt: ${this.inputValue}`;
+                    this.close();
+                    promptSelectGenerateCommand(this.plugin, this.settings, fullPrompt);
+                }))
+            .addButton((btn: ButtonComponent) => btn
+                .setButtonText('Cancel')
+                .onClick(() => {
+                    this.close();
+                }));
+    }
+
+    onClose() {
+        const { contentEl } = this;
+        contentEl.empty();
+    }
+}

--- a/src/components/settings/ConnectionSettings.ts
+++ b/src/components/settings/ConnectionSettings.ts
@@ -40,4 +40,3 @@ export function addAPIConnectionSettings(containerEl: HTMLElement, plugin: BMOGP
     addOpenAIConnectionSettings(settingsContainer, plugin, SettingTab);
     addOpenRouterConnectionSettings(settingsContainer, plugin, SettingTab);
 }
-

--- a/src/components/settings/OllamaSettings.ts
+++ b/src/components/settings/OllamaSettings.ts
@@ -233,7 +233,7 @@ export function addOllamaSettings(containerEl: HTMLElement, plugin: BMOGPT, Sett
             if (isNaN(intValue)) {
                 plugin.settings.OllamaConnection.ollamaParameters.num_thread = DEFAULT_SETTINGS.OllamaConnection.ollamaParameters.num_thread;
             } else {
-                plugin.settings.OllamaConnection.ollamaParameters.num_thread = intValue.toString();
+    new Setting(advancedSettingsContainer)
             }
 
             await plugin.saveSettings();

--- a/src/components/settings/PromptSettings.ts
+++ b/src/components/settings/PromptSettings.ts
@@ -1,5 +1,5 @@
 import { Setting, SettingTab, TFile, TFolder, setIcon } from 'obsidian';
-import BMOGPT, { DEFAULT_SETTINGS } from 'src/main';
+import BMOGPT, { DEFAULT_SETTINGS } from '../../main';
 
 
 // Prompt Settings

--- a/src/components/settings/PromptSettings.ts
+++ b/src/components/settings/PromptSettings.ts
@@ -99,4 +99,62 @@ export function addPromptSettings(containerEl: HTMLElement, plugin: BMOGPT, Sett
                 SettingTab.display();
             })
         );
+
+    new Setting(settingsContainer)
+        .setName('Raw Prompts Folder Path')
+        .setDesc('Directory where raw prompts will be logged.')
+        .addText(text => text
+            .setPlaceholder('BMO/raw-prompts')
+            .setValue(plugin.settings.prompts.rawPromptsFolderPath || DEFAULT_SETTINGS.prompts.rawPromptsFolderPath)
+            .onChange(async (value) => {
+                plugin.settings.prompts.rawPromptsFolderPath = value ? value : DEFAULT_SETTINGS.prompts.rawPromptsFolderPath;
+                if (value) {
+                    let folderPath = plugin.settings.prompts.rawPromptsFolderPath.trim() || DEFAULT_SETTINGS.prompts.rawPromptsFolderPath;
+                    
+                    // Remove trailing '/' if it exists
+                    while (folderPath.endsWith('/')) {
+                        folderPath = folderPath.substring(0, folderPath.length - 1);
+                        plugin.settings.prompts.rawPromptsFolderPath = folderPath;
+                    }
+                    
+                    const folder = plugin.app.vault.getAbstractFileByPath(folderPath);
+                    
+                    if (folder && folder instanceof TFolder) {
+                        text.inputEl.style.borderColor = ''; 
+                    } else {
+                        text.inputEl.style.borderColor = 'red'; 
+                    }
+                }
+                await plugin.saveSettings();
+            })
+            .inputEl.addEventListener('focusout', async () => {
+                SettingTab.display();
+            })
+        );
+
+    new Setting(settingsContainer)
+        .setName('Log Raw Prompts')
+        .setDesc('Save all prompts to markdown files for debugging.')
+        .addToggle(toggle => toggle
+            .setValue(plugin.settings.prompts.logRawPrompts)
+            .onChange(async (value) => {
+                plugin.settings.prompts.logRawPrompts = value;
+                if (value) {
+                    // Create raw prompts directory if it doesn't exist
+                    const folderPath = plugin.settings.prompts.rawPromptsFolderPath || DEFAULT_SETTINGS.prompts.rawPromptsFolderPath;
+                    const bmoFolder = 'BMO';
+
+                    // Create BMO folder if it doesn't exist
+                    if (!await plugin.app.vault.adapter.exists(bmoFolder)) {
+                        await plugin.app.vault.createFolder(bmoFolder);
+                    }
+
+                    // Create raw-prompts folder if it doesn't exist
+                    if (!await plugin.app.vault.adapter.exists(folderPath)) {
+                        await plugin.app.vault.createFolder(folderPath);
+                    }
+                }
+                await plugin.saveSettings();
+            })
+        );
 }

--- a/src/utils/PromptLogger.ts
+++ b/src/utils/PromptLogger.ts
@@ -1,5 +1,5 @@
 import { TFile, Vault } from 'obsidian';
-import { BMOSettings } from '../main';
+import { BMOSettings } from 'src/main';
 
 export async function logRawPrompt(
     vault: Vault,
@@ -17,8 +17,9 @@ export async function logRawPrompt(
 
     try {
         const folderPath = settings.prompts.rawPromptsFolderPath || 'BMO/raw-prompts';
-        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-        const filename = `${timestamp}.md`;
+        const date = new Date();
+        const timestamp = date.toISOString().replace(/[:.]/g, '-');
+        const filename = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')} ${String(date.getHours()).padStart(2, '0')}-${String(date.getMinutes()).padStart(2, '0')}-${String(date.getSeconds()).padStart(2, '0')}.md`;
         const filePath = `${folderPath}/${filename}`;
 
         // Create BMO folder if it doesn't exist

--- a/src/utils/PromptLogger.ts
+++ b/src/utils/PromptLogger.ts
@@ -1,0 +1,57 @@
+import { TFile, Vault } from 'obsidian';
+import { BMOSettings } from '../main';
+
+export async function logRawPrompt(
+    vault: Vault,
+    settings: BMOSettings,
+    prompt: string,
+    model: string,
+    systemRole: string,
+    temperature: string,
+    maxTokens: string
+) {
+    if (!settings.prompts.logRawPrompts) {
+        console.debug('Raw prompt logging disabled');
+        return;
+    }
+
+    try {
+        const folderPath = settings.prompts.rawPromptsFolderPath || 'BMO/raw-prompts';
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+        const filename = `${timestamp}.md`;
+        const filePath = `${folderPath}/${filename}`;
+
+        // Create BMO folder if it doesn't exist
+        const bmoFolder = 'BMO';
+        if (!await vault.adapter.exists(bmoFolder)) {
+            await vault.createFolder(bmoFolder);
+        }
+
+        // Create raw-prompts folder if it doesn't exist
+        if (!await vault.adapter.exists(folderPath)) {
+            await vault.createFolder(folderPath);
+        }
+
+        // Create the content with metadata
+        const content = `---
+timestamp: ${new Date().toISOString()}
+model: ${model}
+temperature: ${temperature}
+max_tokens: ${maxTokens}
+---
+
+# System Role
+
+${systemRole}
+
+# Prompt
+
+${prompt}`;
+
+        // Create the file
+        await vault.create(filePath, content);
+        console.log(`Raw prompt logged to ${filePath}`);
+    } catch (error) {
+        console.error('Error logging raw prompt:', error);
+    }
+}


### PR DESCRIPTION
Added features:
- Inline generation within the editor, with support for streaming, along with associated hotkeys and right-click context menu actions:
 1. Highlight text to limit the generation's context to the highlighted text
 2. Generate text at the cursor location, using what is above the cursor as context (but nothing below the cursor)
 3. Highlight text and use it as context with added instructions (an input popup appears). This is in contrast to the existing feature which uses the highlighted text as a prompt, verbatim.
- An option to automatically create logs of the raw prompts sent to the model. Very useful for debugging and learning how to use the plugin.